### PR TITLE
Fix dependency and cast error

### DIFF
--- a/generateWallpaper.py
+++ b/generateWallpaper.py
@@ -16,9 +16,9 @@ with open("top.out", "r") as topFile:
             command = fields[11].split("/")[0]
         else:
             command = fields[11]
-        
-        cpu = float(fields[8])
-        mem = float(fields[9])
+
+        cpu = float(fields[8].replace(",", "."))
+        mem = float(fields[9].replace(",", "."))
 
         if command != "top":
             commandList.append((command, cpu, mem))

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@
 echo "Installing Python dependencies..."
 pip3 install --user Pillow
 pip3 install --user wordcloud
+pip3 install --user matplotlib
 
 WALLPAPER_PATH="file://$(pwd)/wallpaper.png"
 chmod +x updateWallpaper.sh


### PR DESCRIPTION
- Install matplotlib (if not installed)

- Fixes cast error (occurred on Fedora 30)