### PR TITLE
Added matplotlib to setup and replacing commas with periods in fields

### DIFF
--- a/generateWallpaper.py
+++ b/generateWallpaper.py
@@ -17,8 +17,8 @@ with open("top.out", "r") as topFile:
         else:
             command = fields[11]
         
-        cpu = float(fields[8])
-        mem = float(fields[9])
+        cpu = float(fields[8].replace(',', ''))
+        mem = float(fields[9].replace(',', ''))
 
         if command != "top":
             commandList.append((command, cpu, mem))

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@
 echo "Installing Python dependencies..."
 pip3 install --user Pillow
 pip3 install --user wordcloud
+pip3 install --user matplotlib
 
 WALLPAPER_PATH="file://$(pwd)/wallpaper.png"
 chmod +x updateWallpaper.sh


### PR DESCRIPTION
When I first ran setup it complained about not having `matplotlib`

Also, my `top` fields had commas in them (example: `6,2`) and parsing that to float didn't work. This might be due to some culture settings. Not a python dev so there's probably a better way to do it.