### PR TITLE
fixed some output issues in generateWallpaper.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 top.out
-wallpaper.png
-wc.png
+*.png

--- a/generateWallpaper.py
+++ b/generateWallpaper.py
@@ -14,7 +14,7 @@ with open("top.out", "r") as topFile:
         
         try:
             if fields[11].count("/") > 0:
-                command = fields[11].split("/")[0]
+                command = fields[11].split("/")[-1]
             else:
                 command = fields[11]
 

--- a/updateWallpaper.sh
+++ b/updateWallpaper.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 export DISPLAY=:1
-top -b -n 1 > top.out
+top -b -n 1 -i > top.out
 nice python3 generateWallpaper.py


### PR DESCRIPTION
Fixes #9 :
- Using `top -b -n 1 -i` in **updateWallpaper.sh** to get states of currently inactive programs.
- Using `-1` in **generateWallpaper.py** to get the last part of the split command (which should always be the name of the program, right?)