### PR TITLE
Use click for command line options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python and shell scripts which set your wallpaper to a wordcloud of the most res
 
 ![](https://raw.githubusercontent.com/anirudhajith/process-wallpaper/master/screenshot.png)
 
-## Depenendencies
+## Dependencies
 * `python3`
 * `gsettings` (comes preinstalled with GNOME) or `feh` (supported by many Linux distributions). 
 
@@ -24,9 +24,33 @@ git clone https://github.com/anirudhajith/process-wallpaper.git
 pip3 install -r requirements.txt --user
 ```
 
-## Use
+## Usage
+
 The wallpaper is updated every time `updateWallpaper.sh` is run. To trigger the update every minute, append the following line to `crontab -e`:
 ```
 * * * * * cd /path/to/script/directory && ./updateWallpaper.sh > /tmp/wallpaper.log 2>&1
+```
 
+### CLI
+
+`genWallpaper.py` can also be used as a CLI utility.
+
+```
+$ python3 genWallpaper.py --help
+```
+```
+Usage: generateWallpaper.py [OPTIONS]
+
+Options:
+  -r, --resolution INTEGER...  The resolution (width, height) of the wallpaper
+                               to generate.
+  -bg, --bgcolor TEXT          Background color.
+  -m, --margins INTEGER...     The margins (horizontal, vertical) around the
+                               outside of the text, in pixels.
+  -o, --output FILENAME        Where to output the wallpaper.  [default:
+                               wallpaper.png]
+  --config FILENAME            Path of the config file. Options are overridden
+                               by command line arguments.  [default:
+                               config.json]
+  --help                       Show this message and exit.
 ```

--- a/generateWallpaper.py
+++ b/generateWallpaper.py
@@ -1,75 +1,131 @@
-import re
-from PIL import Image
-from wordcloud import WordCloud
 import json
 import os
+import re
+from typing import Tuple, BinaryIO, TextIO
 
-commandList = []
+import click
+from PIL import Image, ImageColor
+from wordcloud import WordCloud
 
-with open("top.out", "r") as topFile:
-    topOutput = topFile.read().split("\n")[7:]
 
-    for line in topOutput[:-1]:
-        line = re.sub(r'\s+', ' ', line).strip()
-        fields = line.split(" ")
+def get_freqs():
+    commandList = []
+    with open("top.out", "r") as topFile:
+        topOutput = topFile.read().split("\n")[7:]
 
+        for line in topOutput[:-1]:
+            line = re.sub(r'\s+', ' ', line).strip()
+            fields = line.split(" ")
+
+            try:
+                if fields[11].count("/") > 0:
+                    command = fields[11].split("/")[0]
+                else:
+                    command = fields[11]
+
+                cpu = float(fields[8].replace(",", "."))
+                mem = float(fields[9].replace(",", "."))
+
+                if command != "top":
+                    commandList.append((command, cpu, mem))
+            except:
+                pass
+
+    commandDict = {}
+
+    for command, cpu, mem in commandList:
+        if command in commandDict:
+            commandDict[command][0] += cpu
+            commandDict[command][1] += mem
+        else:
+            commandDict[command] = [cpu + 1, mem + 1]
+
+    resourceDict = {}
+    for command, [cpu, mem] in commandDict.items():
+        resourceDict[command] = (cpu ** 2 + mem ** 2) ** 0.5
+
+    return resourceDict
+
+
+def validate_color(ctx, param, value):
+    try:
+        return ImageColor.getrgb(value)
+    except ValueError:
+        raise click.BadParameter('Colors should be CSS3-like strings, e.g. #101010 or rgb(123, 123, 123).')
+
+
+@click.command()
+@click.option(
+    '--resolution', '-r',
+    help='The resolution (width, height) of the wallpaper to generate.',
+    type=(int, int)
+)
+@click.option(
+    '--bgcolor', '-bg',
+    help='Background color.'
+)
+@click.option(
+    '--margins', '-m',
+    help='The margins (horizontal, vertical) around the outside of the text, in pixels.',
+    type=(int, int)
+)
+@click.option(
+    '--output', '-o',
+    help='Where to output the wallpaper.',
+    type=click.File('wb'),
+    default='wallpaper.png',
+    show_default=True
+)
+@click.option(
+    '--config',
+    help='Path of the config file. Options are overridden by command line arguments.',
+    type=click.File('r'),
+    default='config.json',
+    show_default=True
+)
+def main(resolution: Tuple[int, int], bgcolor, margins: Tuple[int, int], output: BinaryIO, config: TextIO):
+    if config:
+        config = json.load(config)
+
+    frequencies = get_freqs()
+
+    if not resolution:
+        width, height = None, None
         try:
-            if fields[11].count("/") > 0:
-                command = fields[11].split("/")[0]
-            else:
-                command = fields[11]
-
-            cpu = float(fields[8].replace(",", "."))
-            mem = float(fields[9].replace(",", "."))
-
-            if command != "top":
-                commandList.append((command, cpu, mem))
+            width, height = ((os.popen("xrandr | grep '*'").read()).split()[0]).split("x")
+            width = int(width)
+            height = int(height)
         except:
             pass
 
-commandDict = {}
-
-for command, cpu, mem in commandList:
-    if command in commandDict:
-        commandDict[command][0] += cpu
-        commandDict[command][1] += mem
+        if not width or not height:
+            width = config['resolution']['width']
+            height = config['resolution']['height']
     else:
-        commandDict[command] = [cpu + 1, mem + 1]
+        width, height = resolution
 
-resourceDict = {}
+    if margins:
+        horiz_margin, vert_margin = margins
+    else:
+        horiz_margin = int(config['wordcloud']['margin'])
+        vert_margin = int(config['wordcloud']['margin'])
+    wc = WordCloud(
+        background_color=bgcolor or config["wordcloud"]["background"],
+        width=width - 2 * horiz_margin,
+        height=height - 2 * vert_margin
+    ).generate_from_frequencies(frequencies)
 
-for command, [cpu, mem] in commandDict.items():
-    resourceDict[command] = (cpu ** 2 + mem ** 2) ** 0.5
+    wc.to_file('wc.png')
 
-width, height = None, None
-try:
-    width, height = ((os.popen("xrandr | grep '*'").read()).split()[0]).split("x")
-    width = int(width)
-    height = int(height)
-except:
-    pass
-
-configJSON = json.loads(open("config.json", "r").read())
-
-if not width or not height:
-    width = configJSON['resolution']['width']
-    height = configJSON['resolution']['height']
-
-wc = WordCloud(
-    background_color=configJSON["wordcloud"]["background"],
-    width=width - 2 * int(configJSON["wordcloud"]["margin"]),
-    height=height - 2 * int(configJSON["wordcloud"]["margin"])
-).generate_from_frequencies(resourceDict)
-
-wc.to_file('wc.png')
-
-wordcloud = Image.open("wc.png")
-wallpaper = Image.new('RGB', (width, height), configJSON["wordcloud"]["background"])
-wallpaper.paste(
-    wordcloud,
-    (
-        configJSON["wordcloud"]["margin"],
-        configJSON["wordcloud"]["margin"]
+    wordcloud = Image.open("wc.png")
+    wallpaper = Image.new('RGB', (width, height), bgcolor or config["wordcloud"]["background"])
+    wallpaper.paste(
+        wordcloud,
+        margins or (config["wordcloud"]["margin"], config["wordcloud"]["margin"])
     )
-)
-wallpaper.save("wallpaper.png")
+
+    wallpaper.save(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/generateWallpaper.py
+++ b/generateWallpaper.py
@@ -58,7 +58,8 @@ def validate_color(ctx, param, value):
 @click.option(
     '--resolution', '-r',
     help='The resolution (width, height) of the wallpaper to generate.',
-    type=(int, int)
+    nargs=2,
+    type=int,
 )
 @click.option(
     '--bgcolor', '-bg',
@@ -67,7 +68,8 @@ def validate_color(ctx, param, value):
 @click.option(
     '--margins', '-m',
     help='The margins (horizontal, vertical) around the outside of the text, in pixels.',
-    type=(int, int)
+    nargs=2,
+    type=int
 )
 @click.option(
     '--output', '-o',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib
 Pillow
 wordcloud
+click


### PR DESCRIPTION
A quick implementation of using `click` to allow users to specify options using command line arguments. Not completely sure if `click` is the *best* option. Might simply want to use `argparse` for better flexibility.