### PR TITLE
Refactor image generation for easier configuration

### DIFF
--- a/generateWallpaper.py
+++ b/generateWallpaper.py
@@ -41,35 +41,33 @@ resourceDict = {}
 for command, [cpu, mem] in commandDict.items():
     resourceDict[command] = (cpu ** 2 + mem ** 2) ** 0.5
 
+configJSON = json.loads(open("config.json", "r").read())
+
 width, height = None, None
 try:
-    width, height = ((os.popen("xrandr | grep '*'").read()).split()[0]).split("x")
-    width = int(width)
-    height = int(height)
+    width = configJSON['resolution']['width']
+    height = configJSON['resolution']['height']
 except:
     pass
 
-configJSON = json.loads(open("config.json", "r").read())
-
+# if width or height were not found in the config try to get it from the system
+# WARNING: this does not work properly for multi monitor setups
 if not width or not height:
-    width = configJSON['resolution']['width']
-    height = configJSON['resolution']['height']
+    try:
+        width, height = ((os.popen("xrandr | grep '*'").read()).split()[0]).split("x")
+        width = int(width)
+        height = int(height)
+    except:
+        pass
 
+# for full API see
+# https://amueller.github.io/word_cloud/generated/wordcloud.WordCloud.html
 wc = WordCloud(
     background_color=configJSON["wordcloud"]["background"],
     width=width - 2 * int(configJSON["wordcloud"]["margin"]),
-    height=height - 2 * int(configJSON["wordcloud"]["margin"])
+    height=height - 2 * int(configJSON["wordcloud"]["margin"]),
+    margin=configJSON["wordcloud"]["margin"]
 ).generate_from_frequencies(resourceDict)
 
-wc.to_file('wc.png')
+wc.to_file('wallpaper.png')
 
-wordcloud = Image.open("wc.png")
-wallpaper = Image.new('RGB', (width, height), configJSON["wordcloud"]["background"])
-wallpaper.paste(
-    wordcloud,
-    (
-        configJSON["wordcloud"]["margin"],
-        configJSON["wordcloud"]["margin"]
-    )
-)
-wallpaper.save("wallpaper.png")


### PR DESCRIPTION
# Description

On a system with multiple screens the wallpaper was still generated with the resolution of only one of the screens. E.g. For three `1920x1080` screens the wallpaper had a resolution of `1920x1080` instead of `5760x1080`. Changing the `config.yaml` didn't help. This PR fixes this issue.

Also the generation of the intermediate image was removed as it is not necessary.

## Changes
- [x] Prefer config over system information.
- [x] Only generate one image and use WordCloud's API to account for the margin.

## Additional Information
Maybe it would be nice to expose more config parameters of WordCloud via the `config.yaml`.